### PR TITLE
Resolves imagekit-developer/imagekit-vuejs #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ See the complete list of transformations supported in ImageKit [here](https://do
 | format | f |
 | radius | r |
 | background | bg |
-| border | bo |
+| border | b |
 | rotation | rt |
 | blur | bl |
 | named | n |

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/imagekit-developer/imagekit-vuejs"
   },
   "dependencies": {
-    "imagekit-javascript": "^1.3.4"
+    "imagekit-javascript": "^1.3.5"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",


### PR DESCRIPTION
This commit bumps up the dependency imagekit-javascript to 1.3.5